### PR TITLE
fixed bug where only one primary sponsor appeared in json file

### DIFF
--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -39,6 +39,7 @@ class NcLegBillsSpider(scrapy.Spider):
         item['title'] = response.xpath('//div[@id = "title"]/a/text()').extract_first()
         item['keywords'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[6]/td/div/text()').re('[^,]+')
         item['counties'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[4]/td/text()').re('[^,]+')
+        item['statutes'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[5]/td/div/text()').re('[^,]+')
 
         # In 2017 member names are embedded in links
         if (self.session == '2017'):

--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -42,7 +42,8 @@ class NcLegBillsSpider(scrapy.Spider):
         # In 2017 member names are embedded in links
         if (self.session == '2017'):
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a/text()').extract()
-            item['primary_sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a[contains(following-sibling::text(), "Primary")]/text()').extract()
+            item['primary_sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a[contains(following-sibling::text(), "Primary")]/preceding-sibling::a/text()').extract()
+            item['primary_sponsors'].extend(response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a[contains(following-sibling::text(), "Primary")]/text()').extract())
         else:
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/text()').re('(?!Primary$)\w+\.?\ ?\-?\'?\w+')
 

--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -42,8 +42,7 @@ class NcLegBillsSpider(scrapy.Spider):
         # In 2017 member names are embedded in links
         if (self.session == '2017'):
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a/text()').extract()
-            item['primary_sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a[contains(following-sibling::text(), "Primary")]/preceding-sibling::a/text()').extract()
-            item['primary_sponsors'].extend(response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a[contains(following-sibling::text(), "Primary")]/text()').extract())
+            item['primary_sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/br/preceding-sibling::a/text()').extract()
         else:
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/text()').re('(?!Primary$)\w+\.?\ ?\-?\'?\w+')
 

--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -38,6 +38,7 @@ class NcLegBillsSpider(scrapy.Spider):
         item['session'] = response.xpath('//div[@id = "mainBody"]/div[3]/text()').extract_first()
         item['title'] = response.xpath('//div[@id = "title"]/a/text()').extract_first()
         item['keywords'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[6]/td/div/text()').re('[^,]+')
+        item['counties'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[4]/td/text()').re('[^,]+')
 
         # In 2017 member names are embedded in links
         if (self.session == '2017'):


### PR DESCRIPTION
Added new line that allowed collection of previous siblings relating to target node.  The fix is for 2017 sessions only.